### PR TITLE
UPDATE: Adding registry.jujucharms.com to the list of https sources.

### DIFF
--- a/check_sources.sh
+++ b/check_sources.sh
@@ -128,6 +128,7 @@ readonly _HTTPS_SOURCES=(
     packages.elastic.co
     artifacts.elastic.co
     packages.elasticsearch.org
+    registry.jujucharms.com
 )
 
 ###############################################################################


### PR DESCRIPTION
Adding registry.jujucharms.com on https as it is requried for COS and Canonical K8s.